### PR TITLE
Detect cargo-nextest as top-level cargo test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.8.1
+
+- When cleaning up old numbered directories if the entry is not found
+  this error is ignored.  This is possible if multiple cleanups are
+  racing each other.
+
 ## v0.8.0
 
 - NumberedDir::create_subdir will no longer ensure to always create a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testdir"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Floris Bruynooghe <flub@devork.be>"]
 edition = "2021"
 description = "Semi-persistent, scoped test directories"

--- a/src/private.rs
+++ b/src/private.rs
@@ -9,7 +9,6 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
 
-// use heim::process::Pid;
 use once_cell::sync::Lazy;
 use sysinfo::{Pid, ProcessExt, SystemExt};
 
@@ -19,7 +18,6 @@ pub use cargo_metadata;
 const CARGO_PID_FILE_NAME: &str = "cargo-pid";
 
 /// Whether we are a cargo sub-process.
-// static CARGO_PID: Lazy<Option<Pid>> = Lazy::new(|| smol::block_on(async { cargo_pid().await }));
 static CARGO_PID: Lazy<Option<Pid>> = Lazy::new(cargo_pid);
 
 /// Returns the process ID of our parent Cargo process.
@@ -45,7 +43,7 @@ fn cargo_pid() -> Option<Pid> {
     let parent = sys.process(ppid)?;
     let parent_exe = parent.exe();
     let parent_file_name = parent_exe.file_name()?;
-    if parent_file_name == OsStr::new("cargo") {
+    if parent_file_name == OsStr::new("cargo") || parent_file_name == OsStr::new("cargo-nextest") {
         Some(parent.pid())
     } else if parent_file_name == OsStr::new("rustdoc") {
         let ppid = parent.parent()?;


### PR DESCRIPTION
This accepts cargo-nextest as the top-level binary that drives a cargo
testrun.  This fixes the re-using of the numbered testdir between all
the processeses started by a testrun under cargo-nextest.  Probably.

Closes #4