### PR TITLE
Improve windows support, test more platforms in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
       - run: cargo doc --no-deps --document-private-items
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/src/numbered_dir.rs
+++ b/src/numbered_dir.rs
@@ -314,12 +314,13 @@ mod tests {
         assert!(dir_0.path().is_dir());
         assert!(dir_1.path().is_dir());
 
-        let current = fs::read_link(parent.path().join("base-current")).unwrap();
-
         // We know that on windows the first symlink probably didn't get removed, symlinks
         // are best-effort there.
         #[cfg(target_family = "unix")]
-        assert_eq!(dir_1.path(), current);
+        {
+            let current = fs::read_link(parent.path().join("base-current")).unwrap();
+            assert_eq!(dir_1.path(), current);
+        }
     }
 
     #[test]

--- a/src/numbered_dir.rs
+++ b/src/numbered_dir.rs
@@ -315,6 +315,10 @@ mod tests {
         assert!(dir_1.path().is_dir());
 
         let current = fs::read_link(parent.path().join("base-current")).unwrap();
+
+        // We know that on windows the first symlink probably didn't get removed, symlinks
+        // are best-effort there.
+        #[cfg(target_family = "unix")]
         assert_eq!(dir_1.path(), current);
     }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -131,7 +131,7 @@ pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
         .filter_map(|x| x.name())
         .map(|x| x.to_string())
     {
-        if let Some(symbol) = symbol.strip_prefix(module_path) {
+        if let Some(symbol) = dbg!(symbol.strip_prefix(module_path)) {
             if let Some(symbol) = symbol.strip_suffix("::{{closure}}") {
                 return symbol.to_string();
             } else {

--- a/src/private.rs
+++ b/src/private.rs
@@ -42,7 +42,7 @@ fn cargo_pid() -> Option<Pid> {
     sys.refresh_process_specifics(ppid, what);
     let parent = sys.process(ppid)?;
     let parent_exe = parent.exe();
-    let parent_file_name = parent_exe.file_name()?;
+    let parent_file_name = dbg!(parent_exe.file_name()?);
     if parent_file_name == OsStr::new("cargo") || parent_file_name == OsStr::new("cargo-nextest") {
         Some(parent.pid())
     } else if parent_file_name == OsStr::new("rustdoc") {

--- a/src/private.rs
+++ b/src/private.rs
@@ -20,16 +20,16 @@ const CARGO_PID_FILE_NAME: &str = "cargo-pid";
 /// Whether we are a cargo sub-process.
 static CARGO_PID: Lazy<Option<Pid>> = Lazy::new(cargo_pid);
 
-#[cfg(target_family == "unix")]
+#[cfg(target_family = "unix")]
 const CARGO_NAME: &str = "cargo";
 
-#[cfg(target_family == "unix")]
+#[cfg(target_family = "unix")]
 const NEXTEST_NAME: &str = "cargo-nextest";
 
-#[cfg(target_family == "windows")]
+#[cfg(target_family = "windows")]
 const CARGO_NAME: &str = "cargo.exe";
 
-#[cfg(target_family == "windows")]
+#[cfg(target_family = "windows")]
 const NEXTEST_NAME: &str = "cargo-nextest.exe";
 
 /// Returns the process ID of our parent Cargo process.

--- a/src/private.rs
+++ b/src/private.rs
@@ -123,7 +123,6 @@ pub fn extract_test_name(module_path: &str) -> String {
 
 /// Extracts the name of the currently executing tests using [`backtrace`].
 pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
-    dbg!(module_path);
     for symbol in backtrace::Backtrace::new()
         .frames()
         .iter()
@@ -132,8 +131,8 @@ pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
         .filter_map(|x| x.name())
         .map(|x| x.to_string())
     {
-        dbg!(&symbol);
-        if let Some(symbol) = dbg!(symbol.strip_prefix(module_path)) {
+        &symbol;
+        if let Some(symbol) = symbol.strip_prefix(module_path) {
             if let Some(symbol) = symbol.strip_suffix("::{{closure}}") {
                 return symbol.to_string();
             } else {
@@ -142,7 +141,7 @@ pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
         }
     }
 
-    // We know that on windows doc tests fallthrough as the module_path is something like
+    // We know that on windows doc tests fall through as the module_path is something like
     // "rust_out" which is not very useful.  We'll have to just use something.
     String::from("unknown_test")
 }

--- a/src/private.rs
+++ b/src/private.rs
@@ -131,7 +131,6 @@ pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
         .filter_map(|x| x.name())
         .map(|x| x.to_string())
     {
-        &symbol;
         if let Some(symbol) = symbol.strip_prefix(module_path) {
             if let Some(symbol) = symbol.strip_suffix("::{{closure}}") {
                 return symbol.to_string();

--- a/src/private.rs
+++ b/src/private.rs
@@ -123,6 +123,7 @@ pub fn extract_test_name(module_path: &str) -> String {
 
 /// Extracts the name of the currently executing tests using [`backtrace`].
 pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
+    dbg!(module_path);
     for symbol in backtrace::Backtrace::new()
         .frames()
         .iter()

--- a/src/private.rs
+++ b/src/private.rs
@@ -20,6 +20,18 @@ const CARGO_PID_FILE_NAME: &str = "cargo-pid";
 /// Whether we are a cargo sub-process.
 static CARGO_PID: Lazy<Option<Pid>> = Lazy::new(cargo_pid);
 
+#[cfg(target_family == "unix")]
+const CARGO_NAME: &str = "cargo";
+
+#[cfg(target_family == "unix")]
+const NEXTEST_NAME: &str = "cargo-nextest";
+
+#[cfg(target_family == "windows")]
+const CARGO_NAME: &str = "cargo.exe";
+
+#[cfg(target_family == "windows")]
+const NEXTEST_NAME: &str = "cargo-nextest.exe";
+
 /// Returns the process ID of our parent Cargo process.
 ///
 /// If our parent process is not Cargo, `None` is returned.
@@ -43,7 +55,7 @@ fn cargo_pid() -> Option<Pid> {
     let parent = sys.process(ppid)?;
     let parent_exe = parent.exe();
     let parent_file_name = dbg!(parent_exe.file_name()?);
-    if parent_file_name == OsStr::new("cargo") || parent_file_name == OsStr::new("cargo-nextest") {
+    if parent_file_name == OsStr::new(CARGO_NAME) || parent_file_name == OsStr::new(NEXTEST_NAME) {
         Some(parent.pid())
     } else if parent_file_name == OsStr::new("rustdoc") {
         let ppid = parent.parent()?;

--- a/src/private.rs
+++ b/src/private.rs
@@ -131,6 +131,7 @@ pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
         .filter_map(|x| x.name())
         .map(|x| x.to_string())
     {
+        dbg!(&symbol);
         if let Some(symbol) = dbg!(symbol.strip_prefix(module_path)) {
             if let Some(symbol) = symbol.strip_suffix("::{{closure}}") {
                 return symbol.to_string();

--- a/src/private.rs
+++ b/src/private.rs
@@ -141,7 +141,10 @@ pub fn extract_test_name_from_backtrace(module_path: &str) -> String {
             }
         }
     }
-    panic!("Cannot determine test name from backtrace");
+
+    // We know that on windows doc tests fallthrough as the module_path is something like
+    // "rust_out" which is not very useful.  We'll have to just use something.
+    String::from("unknown_test")
 }
 
 #[cfg(test)]

--- a/src/private.rs
+++ b/src/private.rs
@@ -54,7 +54,7 @@ fn cargo_pid() -> Option<Pid> {
     sys.refresh_process_specifics(ppid, what);
     let parent = sys.process(ppid)?;
     let parent_exe = parent.exe();
-    let parent_file_name = dbg!(parent_exe.file_name()?);
+    let parent_file_name = parent_exe.file_name()?;
     if parent_file_name == OsStr::new(CARGO_NAME) || parent_file_name == OsStr::new(NEXTEST_NAME) {
         Some(parent.pid())
     } else if parent_file_name == OsStr::new("rustdoc") {


### PR DESCRIPTION
This fixes a few bugs on windows.  Previously the numbered testdir would cylcle
too fast as the test runner was not detected correctly.

Also expand CI tests to run on more platforms so we find those things a bit
faster.