### PR TITLE
Add the missing backtick and documentation references

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,10 +30,13 @@
 /// * Use the scope of the current module: `testdir!(ModuleScope)`.  In this case the crate
 ///   name and module path is used, but with an additional final `mod` component.
 ///
-/// * Directly provide the path using an expression, e.g. `testdir!("sub/dir").  This
+/// * Directly provide the path using an expression, e.g. `testdir!("sub/dir")`.  This
 ///   expression will be passed to [`NumberedDir::create_subdir`] and thus must evaluate to
 ///   something which implements ``AsRef<Path>``, e.g. a simple `"sub/dir"` can be used or
 ///   something more advanced evaluating to a path, usually [`Path`] or [`PathBuf`].
+///
+/// [`NumberedDir::create_subdir`]: crate::NumberedDir::create_subdir
+/// [`Path`]: std::path::Path
 ///
 /// # Panics
 ///


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/cd3002a1-3898-4233-83af-0ff1115d34ce)

After:

![image](https://github.com/user-attachments/assets/9b96b31c-3175-4499-a9f7-7930768aa573)

